### PR TITLE
Feature/find client accommodations

### DIFF
--- a/client/src/main/java/tds/config/Accommodation.java
+++ b/client/src/main/java/tds/config/Accommodation.java
@@ -23,7 +23,7 @@ public class Accommodation {
     private String dependsOnToolType;
     private String typeMode;
     private String segmentKey;
-    private int valueCount;
+    private int typeTotal;
 
     public static final String ACCOMMODATION_TYPE_LANGUAGE = "Language";
 
@@ -163,8 +163,8 @@ public class Accommodation {
         return segmentKey;
     }
 
-    public int getValueCount() {
-        return valueCount;
+    public int getTypeTotal() {
+        return typeTotal;
     }
 
     public static final class Builder {
@@ -187,7 +187,7 @@ public class Accommodation {
         private String typeMode;
         private boolean allowChange;
         private String segmentKey;
-        private int valueCount;
+        private int typeTotal;
 
         public Builder withSegmentPosition(int segmentPosition) {
             this.segmentPosition = segmentPosition;
@@ -284,8 +284,8 @@ public class Accommodation {
             return this;
         }
 
-        public Builder withValueCount(int valueCount) {
-            this.valueCount = valueCount;
+        public Builder withTypeTotal(int typeTotal) {
+            this.typeTotal = typeTotal;
             return this;
         }
 
@@ -310,7 +310,7 @@ public class Accommodation {
             accommodation.typeMode = this.typeMode;
             accommodation.allowChange = this.allowChange;
             accommodation.segmentKey = this.segmentKey;
-            accommodation.valueCount = this.valueCount;
+            accommodation.typeTotal = this.typeTotal;
             return accommodation;
         }
     }

--- a/client/src/main/java/tds/config/Accommodation.java
+++ b/client/src/main/java/tds/config/Accommodation.java
@@ -23,8 +23,12 @@ public class Accommodation {
     private String dependsOnToolType;
     private String typeMode;
     private String segmentKey;
+    private int valueCount;
 
     public static final String ACCOMMODATION_TYPE_LANGUAGE = "Language";
+
+    private Accommodation() {
+    }
 
     /**
      * @return the segment position which relates to this accommodation.  Zero if non segmented assessment
@@ -159,6 +163,10 @@ public class Accommodation {
         return segmentKey;
     }
 
+    public int getValueCount() {
+        return valueCount;
+    }
+
     public static final class Builder {
         private int segmentPosition;
         private boolean disableOnGuestSession;
@@ -179,6 +187,7 @@ public class Accommodation {
         private String typeMode;
         private boolean allowChange;
         private String segmentKey;
+        private int valueCount;
 
         public Builder withSegmentPosition(int segmentPosition) {
             this.segmentPosition = segmentPosition;
@@ -275,6 +284,11 @@ public class Accommodation {
             return this;
         }
 
+        public Builder withValueCount(int valueCount) {
+            this.valueCount = valueCount;
+            return this;
+        }
+
         public Accommodation build() {
             Accommodation accommodation = new Accommodation();
             accommodation.toolValueSortOrder = this.toolValueSortOrder;
@@ -296,6 +310,7 @@ public class Accommodation {
             accommodation.typeMode = this.typeMode;
             accommodation.allowChange = this.allowChange;
             accommodation.segmentKey = this.segmentKey;
+            accommodation.valueCount = this.valueCount;
             return accommodation;
         }
     }

--- a/service/src/main/java/tds/config/repositories/AccommodationsQueryRepository.java
+++ b/service/src/main/java/tds/config/repositories/AccommodationsQueryRepository.java
@@ -15,7 +15,7 @@ public interface AccommodationsQueryRepository {
      * @param assessmentKey the assessment key for lookup
      * @return List of {@link tds.config.Accommodation}
      */
-    List<Accommodation> findAccommodationsForSegmentedAssessment(String assessmentKey);
+    List<Accommodation> findAccommodationsForSegmentedAssessmentByKey(String assessmentKey);
 
     /**
      * Finds the accommodations for an assessment without segments
@@ -24,5 +24,14 @@ public interface AccommodationsQueryRepository {
      * @param languageCodes the included language codes for the accommodations
      * @return List of {@link tds.config.Accommodation}
      */
-    List<Accommodation> findAccommodationsForNonSegmentedAssessment(String assessmentKey, Set<String> languageCodes);
+    List<Accommodation> findAccommodationsForNonSegmentedAssessmentByKey(String assessmentKey, Set<String> languageCodes);
+
+    /**
+     * Finds the accommodations for an assessment id an client
+     *
+     * @param clientName   the client name for the accommodations
+     * @param assessmentId the assessment id for the accommodations
+     * @return list of {@link tds.config.Accommodation}
+     */
+    List<Accommodation> findAssessmentAccommodationsById(String clientName, String assessmentId);
 }

--- a/service/src/main/java/tds/config/repositories/impl/AccommodationsQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/config/repositories/impl/AccommodationsQueryRepositoryImpl.java
@@ -39,6 +39,7 @@ public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRep
         "  TType.IsVisible as isVisible, \n" +
         "  TType.studentControl as studentControl, \n" +
         "  null as dependsOnToolType, \n" +
+        "  (select count(1) from client_testtool TOOL where TOOL.ContextType = 'TEST' and TOOL.Context = MODE.testID and TOOL.clientname = MODE.clientname and TOOL.Type = TT.Type) as ValCount, \n" +
         "  IsEntryControl as isEntryControl\n" +
         "FROM \n" +
         "  configs.client_testmode MODE \n" +
@@ -78,6 +79,7 @@ public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRep
         "  TType.IsVisible as isVisible, \n" +
         "  TType.studentControl as studentControl,\n" +
         "  TType.DependsOnToolType as dependsOnToolType, \n" +
+        "  (select count(1) from client_testtool TOOL where TOOL.ContextType = 'TEST' and TOOL.Context = MODE.testID  and TOOL.clientname = MODE.clientname and TOOL.Type = TT.Type) as ValCount, \n" +
         "  TType.IsEntryControl as isEntryControl\n" +
         "FROM \n" +
         "  configs.client_testtooltype TType \n" +
@@ -266,6 +268,7 @@ public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRep
             "  TType.IsVisible as isVisible, \n" +
             "  TType.studentControl as studentControl, \n" +
             "  TType.DependsOnToolType as dependsOnToolType, \n" +
+            "  (select count(1) from client_testtool TOOL where TOOL.ContextType = 'TEST' and TOOL.Context = '*' and TOOL.clientname = MODE.clientname and TOOL.Type = TT.Type) as ValCount, " +
             "  TType.IsEntryControl as isEntryControl\n" +
             "FROM  \n" +
             "  configs.client_testmode MODE\n" +
@@ -311,6 +314,7 @@ public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRep
                 .withDependsOnToolType(rs.getString("dependsOnToolType"))
                 .withEntryControl(rs.getBoolean("isEntryControl"))
                 .withSegmentKey(rs.getString("segmentKey"))
+                .withTypeTotal(rs.getInt("ValCount"))
                 .build();
         }
     }

--- a/service/src/main/java/tds/config/repositories/impl/AccommodationsQueryRepositoryImpl.java
+++ b/service/src/main/java/tds/config/repositories/impl/AccommodationsQueryRepositoryImpl.java
@@ -1,10 +1,14 @@
 package tds.config.repositories.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.RowMapper;
 import org.springframework.jdbc.core.namedparam.MapSqlParameterSource;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
+import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -16,7 +20,7 @@ import tds.config.repositories.AccommodationsQueryRepository;
 public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRepository {
     private final NamedParameterJdbcTemplate jdbcTemplate;
 
-    private static final String SEGMENTED_ASSESSMENT_SQL = "SELECT \n" +
+    private static final String SEGMENTED_ASSESSMENT_BY_KEY_SQL = "SELECT \n" +
         "  distinct SegmentPosition as segment,\n" +
         "  SEG.modekey as segmentKey, \n" +
         "  TType.DisableOnGuestSession as disableOnGuestSession, \n" +
@@ -55,7 +59,7 @@ public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRep
         "  and (TType.TestMode = 'ALL' AND TT.TestMode = 'ALL') \n" +
         "  or (TType.TestMode = MODE.mode and TT.TestMode = MODE.mode) \n";
 
-    private static final String NON_SEGMENTED_ASSESSMENT_SQL = "SELECT \n" +
+    private static final String NON_SEGMENTED_ASSESSMENT_BY_KEY_SQL = "SELECT \n" +
         "  distinct 0 as segment, \n" +
         "  null as segmentKey, \n" +
         "  TType.DisableOnGuestSession as disableOnGuestSession, \n" +
@@ -99,24 +103,146 @@ public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRep
     }
 
     @Override
-    public List<Accommodation> findAccommodationsForSegmentedAssessment(String assessmentKey) {
-        return findAssessmentAccommodations(assessmentKey, true, new HashSet<>());
+    public List<Accommodation> findAccommodationsForSegmentedAssessmentByKey(String assessmentKey) {
+        return findAssessmentAccommodationsByKey(assessmentKey, true, new HashSet<>());
     }
 
     @Override
-    public List<Accommodation> findAccommodationsForNonSegmentedAssessment(String assessmentKey, Set<String> languageCodes) {
-        return findAssessmentAccommodations(assessmentKey, false, languageCodes);
+    public List<Accommodation> findAccommodationsForNonSegmentedAssessmentByKey(String assessmentKey, Set<String> languageCodes) {
+        return findAssessmentAccommodationsByKey(assessmentKey, false, languageCodes);
     }
 
-    private List<Accommodation> findAssessmentAccommodations(String assessmentKey, boolean segmented, Set<String> languageCodes) {
+    @Override
+    public List<Accommodation> findAssessmentAccommodationsById(String clientName, String assessmentId) {
+        SqlParameterSource parameters = new MapSqlParameterSource("assessmentId", assessmentId)
+            .addValue("clientName", clientName);
+
+        String SQL = "(\n" +
+            "SELECT\n" +
+            "  DISTINCT 0 AS segment, \n" +
+            "  NULL AS segmentKey, \n" +
+            "  TType.DisableOnGuestSession AS disableOnGuestSession, \n" +
+            "  TType.SortOrder AS toolTypeSortOrder, \n" +
+            "  TT.SortOrder AS toolValueSortOrder, \n" +
+            "  TType.TestMode AS typeMode,\n" +
+            "  TT.TestMode AS toolMode, \n" +
+            "  TT.Type AS accType, \n" +
+            "  TT.Value AS accValue, \n" +
+            "  TT.Code AS accCode, \n" +
+            "  TT.IsDefault AS isDefault, \n" +
+            "  TT.AllowCombine AS allowCombine, \n" +
+            "  TType.IsFunctional AS isFunctional, \n" +
+            "  TType.AllowChange AS allowChange, \n" +
+            "  TType.IsSelectable AS isSelectable, \n" +
+            "  TType.IsVisible AS isVisible, \n" +
+            "  TType.studentControl AS studentControl,\n" +
+            "  TType.DependsOnToolType AS dependsOnToolType, \n" +
+            "  (SELECT count(1) FROM client_testtool TOOL WHERE TOOL.ContextType = 'TEST' AND TOOL.Context = :assessmentId AND TOOL.clientname = :clientName AND TOOL.Type = TT.Type) AS ValCount,    \n" +
+            "  TType.IsEntryControl AS isEntryControl\n" +
+            "FROM\n" +
+            "  configs.client_testtooltype TType\n" +
+            "JOIN configs.client_testtool TT \n" +
+            "  ON TType.context = TT.context\n" +
+            "  AND TType.clientname = TT.clientname\n" +
+            "  AND TType.contexttype = TT.contexttype\n" +
+            "  AND TType.toolname = TT.type\n" +
+            "WHERE\n" +
+            "  TType.contexttype = 'TEST'\n" +
+            "  AND TType.context = :assessmentId\n" +
+            "  AND TType.clientname = :clientName\n" +
+            ") UNION ALL (\n" +
+            "SELECT\n" +
+            "  DISTINCT SegmentPosition AS segment, \n" +
+            "  SEG.modekey AS segmentKey,\n" +
+            "  TType.DisableOnGuestSession AS disableOnGuestSession, \n" +
+            "  TType.SortOrder AS toolTypeSortOrder, \n" +
+            "  TT.SortOrder AS toolValueSortOrder, \n" +
+            "  TType.TestMode AS typeMode, \n" +
+            "  TT.TestMode AS toolMode, \n" +
+            "  TT.Type AS accType, \n" +
+            "  TT.Value AS accValue, \n" +
+            "  TT.Code AS accCode, \n" +
+            "  TT.IsDefault AS isDefault, \n" +
+            "  TT.AllowCombine AS allowCombine, \n" +
+            "  TType.IsFunctional AS isFunctional, \n" +
+            "  TType.AllowChange AS allowChange, \n" +
+            "  TType.IsSelectable AS isSelectable, \n" +
+            "  TType.IsVisible AS isVisible, \n" +
+            "  TType.studentControl AS studentControl, \n" +
+            "  NULL AS dependsOnToolType, \n" +
+            "  (SELECT count(1) FROM client_testtool TOOL WHERE TOOL.ContextType = 'TEST' AND TOOL.Context = :assessmentId AND TOOL.clientname = :clientName AND TOOL.Type = TT.Type) AS ValCount,  \n" +
+            "  IsEntryControl AS isEntryControl \n" +
+            "FROM\n" +
+            "  configs.client_testtooltype TType\n" +
+            "JOIN configs.client_testtool TT \n" +
+            "  ON TType.context = TT.context\n" +
+            "  AND TType.clientname = TT.clientname\n" +
+            "  AND TType.contexttype = TT.contexttype\n" +
+            "  AND TType.toolname = TT.type\n" +
+            "JOIN \n" +
+            "  configs.client_segmentproperties SEG\n" +
+            "  ON TType.context = SEG.segmentid\n" +
+            "WHERE\n" +
+            "  SEG.parenttest = :assessmentId\n" +
+            "  AND TType.contexttype = 'SEGMENT'\n" +
+            "  AND TType.clientname = :clientName\n" +
+            ") UNION ALL (\n" +
+            "SELECT \n" +
+            "  DISTINCT 0 AS segment,\n" +
+            "  NULL AS segmentKey, \n" +
+            "  TType.DisableOnGuestSession AS disableOnGuestSession,  \n" +
+            "  TType.SortOrder AS toolTypeSortOrder, \n" +
+            "  TT.SortOrder AS toolValueSortOrder, \n" +
+            "  TType.TestMode AS typeMode, \n" +
+            "  TT.TestMode AS toolMode, \n" +
+            "  TT.Type AS accType, \n" +
+            "  TT.Value AS accValue, \n" +
+            "  TT.Code AS accCode, \n" +
+            "  TT.IsDefault AS isDefault, \n" +
+            "  TT.AllowCombine AS allowCombine, \n" +
+            "  TType.IsFunctional AS isFunctional, \n" +
+            "  TType.AllowChange AS allowChange, \n" +
+            "  TType.IsSelectable AS isSelectable, \n" +
+            "  TType.IsVisible AS isVisible, \n" +
+            "  TType.studentControl AS studentControl, \n" +
+            "  TType.DependsOnToolType AS dependsOnToolType, \n" +
+            "  (SELECT count(1) FROM client_testtool TOOL WHERE TOOL.ContextType = 'TEST' AND TOOL.Context = '*' AND TOOL.clientname = :clientName AND TOOL.Type = TT.Type) AS ValCount, \n" +
+            "  TType.IsEntryControl AS isEntryControl\n" +
+            "FROM\n" +
+            "  configs.client_testtooltype TType\n" +
+            "JOIN configs.client_testtool TT \n" +
+            "  ON TType.context = TT.context\n" +
+            "  AND TType.clientname = TT.clientname\n" +
+            "  AND TType.contexttype = TT.contexttype\n" +
+            "  AND TType.toolname = TT.type\n" +
+            "WHERE\n" +
+            "  TType.contexttype = 'TEST'\n" +
+            "  AND TType.context = '*'\n" +
+            "  AND TType.clientname = :clientName\n" +
+            "  AND NOT EXISTS \n" +
+            "    (\n" +
+            "      SELECT \n" +
+            "        toolname \n" +
+            "      FROM configs.client_testtooltype Tool \n" +
+            "      WHERE Tool.ContextType = 'TEST' \n" +
+            "        AND Tool.Context = :assessmentId \n" +
+            "        AND Tool.Toolname = TType.Toolname \n" +
+            "        AND Tool.Clientname = :clientName\n" +
+            "    )\n" +
+            ")";
+
+        return jdbcTemplate.query(SQL, parameters, new ResultSetRowMapper());
+    }
+
+    private List<Accommodation> findAssessmentAccommodationsByKey(String assessmentKey, boolean segmented, Set<String> languageCodes) {
         MapSqlParameterSource parameters = new MapSqlParameterSource("testKey", assessmentKey)
             .addValue("languages", languageCodes);
 
         String SQL;
         if (segmented) {
-            SQL = "(" + SEGMENTED_ASSESSMENT_SQL + ")";
+            SQL = "(" + SEGMENTED_ASSESSMENT_BY_KEY_SQL + ")";
         } else {
-            SQL = "(" + NON_SEGMENTED_ASSESSMENT_SQL + ")";
+            SQL = "(" + NON_SEGMENTED_ASSESSMENT_BY_KEY_SQL + ")";
         }
 
         SQL += "UNION ALL \n " +
@@ -159,8 +285,13 @@ public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRep
             "  and not exists (select * from configs.client_testtooltype Tool where Tool.ContextType = 'TEST' and Tool.Context = MODE.testID and Tool.Toolname = TType.Toolname and Tool.Clientname = MODE.clientname)\n" +
             ")";
 
-        return jdbcTemplate.query(SQL, parameters, (rs, rowNum) ->
-            new Accommodation.Builder()
+        return jdbcTemplate.query(SQL, parameters, new ResultSetRowMapper());
+    }
+
+    private static class ResultSetRowMapper implements RowMapper<Accommodation> {
+        @Override
+        public Accommodation mapRow(ResultSet rs, int i) throws SQLException {
+            return new tds.config.Accommodation.Builder()
                 .withSegmentPosition(rs.getInt("segment"))
                 .withDisableOnGuestSession(rs.getBoolean("disableOnGuestSession"))
                 .withToolTypeSortOrder(rs.getInt("toolTypeSortOrder"))
@@ -180,7 +311,7 @@ public class AccommodationsQueryRepositoryImpl implements AccommodationsQueryRep
                 .withDependsOnToolType(rs.getString("dependsOnToolType"))
                 .withEntryControl(rs.getBoolean("isEntryControl"))
                 .withSegmentKey(rs.getString("segmentKey"))
-                .build()
-        );
+                .build();
+        }
     }
 }

--- a/service/src/main/java/tds/config/services/AccommodationsService.java
+++ b/service/src/main/java/tds/config/services/AccommodationsService.java
@@ -9,10 +9,19 @@ import tds.config.Accommodation;
  */
 public interface AccommodationsService {
     /**
-     * Finds the configuration accommodations for an assessment key
+     * Finds the assessment accommodations for an assessment key
      *
      * @param assessmentKey the assessment's key
      * @return list of {@link tds.config.Accommodation}
      */
-    List<Accommodation> findAccommodations(String assessmentKey);
+    List<Accommodation> findAccommodationsByAssessmentKey(String assessmentKey);
+
+    /**
+     * Finds the assessment accommodations for an assessment id
+     *
+     * @param clientName   the client name
+     * @param assessmentId the id for the assessment
+     * @return
+     */
+    List<Accommodation> findAccommodationsByAssessmentId(String clientName, String assessmentId);
 }

--- a/service/src/main/java/tds/config/services/impl/AccommodationServiceImpl.java
+++ b/service/src/main/java/tds/config/services/impl/AccommodationServiceImpl.java
@@ -3,11 +3,9 @@ package tds.config.services.impl;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Consumer;
 import java.util.stream.Collectors;
 
 import tds.assessment.Assessment;
@@ -30,7 +28,7 @@ public class AccommodationServiceImpl implements AccommodationsService {
     }
 
     @Override
-    public List<Accommodation> findAccommodations(String assessmentKey) {
+    public List<Accommodation> findAccommodationsByAssessmentKey(String assessmentKey) {
         //Implements the replacement for CommonDLL.TestKeyAccommodations_FN
         Optional<Assessment> maybeAssessment = assessmentService.findAssessment(assessmentKey);
         if (!maybeAssessment.isPresent()) {
@@ -40,18 +38,23 @@ public class AccommodationServiceImpl implements AccommodationsService {
         Assessment assessment = maybeAssessment.get();
 
         if (assessment.isSegmented()) {
-            return accommodationsQueryRepository.findAccommodationsForSegmentedAssessment(assessmentKey);
+            return accommodationsQueryRepository.findAccommodationsForSegmentedAssessmentByKey(assessmentKey);
         } else {
             Set<String> languages =
                 assessment.getSegments().stream()
                     .flatMap(segment -> segment.getItems().stream()
                         .flatMap(item -> item.getItemProperties().stream()
                             .filter(itemProperty -> itemProperty.getName().equalsIgnoreCase(Accommodation.ACCOMMODATION_TYPE_LANGUAGE)))
-                        .map(itemProperty -> itemProperty.getValue()))
+                        .map(ItemProperty::getValue))
                     .collect(Collectors.toSet());
 
 
-            return accommodationsQueryRepository.findAccommodationsForNonSegmentedAssessment(assessment.getKey(), languages);
+            return accommodationsQueryRepository.findAccommodationsForNonSegmentedAssessmentByKey(assessment.getKey(), languages);
         }
+    }
+
+    @Override
+    public List<Accommodation> findAccommodationsByAssessmentId(String clientName, String assessmentId) {
+        return accommodationsQueryRepository.findAssessmentAccommodationsById(clientName, assessmentId);
     }
 }

--- a/service/src/main/java/tds/config/web/endpoints/AccommodationController.java
+++ b/service/src/main/java/tds/config/web/endpoints/AccommodationController.java
@@ -6,6 +6,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -14,8 +15,10 @@ import java.util.List;
 import tds.config.Accommodation;
 import tds.config.services.AccommodationsService;
 
+import static org.springframework.util.StringUtils.isEmpty;
+
 @RestController
-@RequestMapping("/config/accommodations")
+@RequestMapping("/config/")
 public class AccommodationController {
     private final AccommodationsService accommodationsService;
 
@@ -24,10 +27,20 @@ public class AccommodationController {
         this.accommodationsService = accommodationsService;
     }
 
-    @GetMapping(value = "/{assessmentKey}", produces = MediaType.APPLICATION_JSON_VALUE)
+    @GetMapping(value = "{clientName}/accommodations/{assessmentKey}", produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseBody
     ResponseEntity<List<Accommodation>> findAccommodations(@PathVariable final String assessmentKey) {
-        final List<Accommodation> accommodations = accommodationsService.findAccommodations(assessmentKey);
+        final List<Accommodation> accommodations = accommodationsService.findAccommodationsByAssessmentKey(assessmentKey);
         return ResponseEntity.ok(accommodations);
+    }
+
+    @GetMapping(value = "{clientName}/accommodations", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    ResponseEntity<List<Accommodation>> findAccommodations(@PathVariable final String clientName, @RequestParam(value = "assessmentId", required = false) String assessmentId) {
+        if (isEmpty(assessmentId)) {
+            throw new IllegalArgumentException("assessment id is required");
+        }
+
+        return ResponseEntity.ok(accommodationsService.findAccommodationsByAssessmentId(clientName, assessmentId));
     }
 }

--- a/service/src/test/java/tds/config/repositories/impl/AccommodationsQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/config/repositories/impl/AccommodationsQueryRepositoryImplIntegrationTests.java
@@ -90,6 +90,7 @@ public class AccommodationsQueryRepositoryImplIntegrationTests {
         assertThat(segmentAccommodation.isFunctional()).isTrue();
         assertThat(segmentAccommodation.isSelectable()).isFalse();
         assertThat(segmentAccommodation.isVisible()).isTrue();
+        assertThat(segmentAccommodation.getTypeTotal()).isEqualTo(0);
         assertThat(segmentAccommodation.getSegmentKey()).isEqualTo("(SBAC_PT)SBAC-Mathematics-11-Spring-2013-2015");
 
         assertThat(defaultAccommodation.getCode()).isEqualTo("toolTypeDefault");
@@ -109,6 +110,7 @@ public class AccommodationsQueryRepositoryImplIntegrationTests {
         assertThat(defaultAccommodation.isFunctional()).isTrue();
         assertThat(defaultAccommodation.isSelectable()).isFalse();
         assertThat(defaultAccommodation.isVisible()).isTrue();
+        assertThat(defaultAccommodation.getTypeTotal()).isEqualTo(1);
         assertThat(defaultAccommodation.getSegmentKey()).isNull();
     }
 
@@ -140,6 +142,7 @@ public class AccommodationsQueryRepositoryImplIntegrationTests {
         assertThat(englishAccommodation.isFunctional()).isTrue();
         assertThat(englishAccommodation.isSelectable()).isFalse();
         assertThat(englishAccommodation.isVisible()).isTrue();
+        assertThat(englishAccommodation.getTypeTotal()).isEqualTo(2);
         assertThat(englishAccommodation.getSegmentKey()).isNull();
 
         assertThat(defaultAccommodation.getCode()).isEqualTo("toolTypeDefault");
@@ -159,6 +162,7 @@ public class AccommodationsQueryRepositoryImplIntegrationTests {
         assertThat(defaultAccommodation.isFunctional()).isTrue();
         assertThat(defaultAccommodation.isSelectable()).isFalse();
         assertThat(defaultAccommodation.isVisible()).isTrue();
+        assertThat(defaultAccommodation.getTypeTotal()).isEqualTo(1);
         assertThat(defaultAccommodation.getSegmentKey()).isNull();
     }
 

--- a/service/src/test/java/tds/config/repositories/impl/AccommodationsQueryRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/config/repositories/impl/AccommodationsQueryRepositoryImplIntegrationTests.java
@@ -65,8 +65,8 @@ public class AccommodationsQueryRepositoryImplIntegrationTests {
     }
 
     @Test
-    public void shouldFindAccommodationsForSegmentAndDefault() {
-        List<Accommodation> accommodationList = repository.findAccommodationsForSegmentedAssessment("(SBAC_PT)SBAC-Mathematics-11-Spring-2013-2015");
+    public void shouldFindAccommodationsForSegmentAndDefaultByAssessmentKey() {
+        List<Accommodation> accommodationList = repository.findAccommodationsForSegmentedAssessmentByKey("(SBAC_PT)SBAC-Mathematics-11-Spring-2013-2015");
 
         assertThat(accommodationList).hasSize(2);
 
@@ -113,10 +113,10 @@ public class AccommodationsQueryRepositoryImplIntegrationTests {
     }
 
     @Test
-    public void shouldFindAccommodationsForNonSegmentAndDefault() {
+    public void shouldFindAccommodationsForNonSegmentAndDefaultByAssessmentKey() {
         Set<String> languages = new HashSet<>();
         languages.add("ENU");
-        List<Accommodation> accommodationList = repository.findAccommodationsForNonSegmentedAssessment("(SBAC_PT)SBAC-Mathematics-11-Spring-2013-2015", languages);
+        List<Accommodation> accommodationList = repository.findAccommodationsForNonSegmentedAssessmentByKey("(SBAC_PT)SBAC-Mathematics-11-Spring-2013-2015", languages);
 
         assertThat(accommodationList).hasSize(2);
 
@@ -160,5 +160,11 @@ public class AccommodationsQueryRepositoryImplIntegrationTests {
         assertThat(defaultAccommodation.isSelectable()).isFalse();
         assertThat(defaultAccommodation.isVisible()).isTrue();
         assertThat(defaultAccommodation.getSegmentKey()).isNull();
+    }
+
+    @Test
+    public void shouldFindAccommodationsByAssessmentIdAndClientName() {
+        List<Accommodation> accommodationList = repository.findAssessmentAccommodationsById("SBAC_PT", "SBAC-Mathematics-11");
+        assertThat(accommodationList).hasSize(4);
     }
 }

--- a/service/src/test/java/tds/config/services/impl/AccommodationsServiceImplTest.java
+++ b/service/src/test/java/tds/config/services/impl/AccommodationsServiceImplTest.java
@@ -55,7 +55,7 @@ public class AccommodationsServiceImplTest {
     @Test (expected = NotFoundException.class)
     public void shouldThrowNotFoundWhenAssessmentCannotBeFound() {
         when(assessmentService.findAssessment("id")).thenReturn(Optional.empty());
-        accommodationsService.findAccommodations("id");
+        accommodationsService.findAccommodationsByAssessmentKey("id");
     }
 
     @Test
@@ -70,10 +70,10 @@ public class AccommodationsServiceImplTest {
         Accommodation accommodation = new Accommodation.Builder().build();
 
         when(assessmentService.findAssessment("key")).thenReturn(Optional.of(assessment));
-        when(accommodationsQueryRepository.findAccommodationsForSegmentedAssessment("key"))
+        when(accommodationsQueryRepository.findAccommodationsForSegmentedAssessmentByKey("key"))
             .thenReturn(Collections.singletonList(accommodation));
 
-        List<Accommodation> accommodationList = accommodationsService.findAccommodations("key");
+        List<Accommodation> accommodationList = accommodationsService.findAccommodationsByAssessmentKey("key");
 
         assertThat(accommodationList).containsExactly(accommodation);
     }
@@ -106,16 +106,26 @@ public class AccommodationsServiceImplTest {
         when(assessmentService.findAssessment("key")).thenReturn(Optional.of(assessment));
 
         when(accommodationsQueryRepository
-            .findAccommodationsForNonSegmentedAssessment(isA(String.class), anySetOf(String.class)))
+            .findAccommodationsForNonSegmentedAssessmentByKey(isA(String.class), anySetOf(String.class)))
             .thenReturn(Collections.singletonList(accommodation));
 
-        List<Accommodation> accommodations = accommodationsService.findAccommodations("key");
+        List<Accommodation> accommodations = accommodationsService.findAccommodationsByAssessmentKey("key");
 
         verify(accommodationsQueryRepository)
-            .findAccommodationsForNonSegmentedAssessment(isA(String.class), languageCaptor.capture());
+            .findAccommodationsForNonSegmentedAssessmentByKey(isA(String.class), languageCaptor.capture());
 
         assertThat(accommodations).containsExactly(accommodation);
         assertThat(languageCaptor.getValue()).containsOnly("ENU", "FRN", "Braille");
+    }
+
+    @Test
+    public void shouldFindAccommodationsById() {
+        Accommodation accommodation = new Accommodation.Builder().build();
+
+        when(accommodationsQueryRepository.findAssessmentAccommodationsById("SBAC_PT", "clientName")).thenReturn(Collections.singletonList(accommodation));
+        List<Accommodation> accommodations = accommodationsService.findAccommodationsByAssessmentId("SBAC_PT", "clientName");
+
+        assertThat(accommodations).containsExactly(accommodation);
     }
 }
 

--- a/service/src/test/java/tds/config/web/endpoints/AccommodationControllerIntegrationTests.java
+++ b/service/src/test/java/tds/config/web/endpoints/AccommodationControllerIntegrationTests.java
@@ -33,7 +33,7 @@ public class AccommodationControllerIntegrationTests {
     private AccommodationsService mockAccommodationsService;
 
     @Test
-    public void shouldGetAClientTestProperty() throws Exception {
+    public void shouldFindAccommodationsByKey() throws Exception {
         Accommodation accommodation = new Accommodation.Builder()
             .withDefaultAccommodation(true)
             .withAccommodationCode("code")
@@ -52,9 +52,9 @@ public class AccommodationControllerIntegrationTests {
             .withVisible(true)
             .build();
 
-        when(mockAccommodationsService.findAccommodations("key")).thenReturn(singletonList(accommodation));
+        when(mockAccommodationsService.findAccommodationsByAssessmentKey("key")).thenReturn(singletonList(accommodation));
 
-        String requestUri = UriComponentsBuilder.fromUriString("/config/accommodations/key")
+        String requestUri = UriComponentsBuilder.fromUriString("/config/SBAC/accommodations/key")
             .build()
             .toUriString();
 
@@ -76,5 +76,62 @@ public class AccommodationControllerIntegrationTests {
             .andExpect(jsonPath("[0].toolValueSortOrder", is(50)))
             .andExpect(jsonPath("[0].visible", is(true)))
             .andExpect(jsonPath("[0].type", is("type")));
+    }
+
+    @Test
+    public void shouldFindAccommodations() throws Exception {
+        Accommodation accommodation = new Accommodation.Builder()
+            .withDefaultAccommodation(true)
+            .withAccommodationCode("code")
+            .withAccommodationType("type")
+            .withAccommodationValue("value")
+            .withAllowChange(true)
+            .withDependsOnToolType("depends")
+            .withAllowCombine(false)
+            .withDisableOnGuestSession(true)
+            .withEntryControl(false)
+            .withFunctional(true)
+            .withSegmentPosition(99)
+            .withToolMode("toolMode")
+            .withToolTypeSortOrder(25)
+            .withToolValueSortOrder(50)
+            .withVisible(true)
+            .build();
+
+        when(mockAccommodationsService.findAccommodationsByAssessmentId("SBAC","id")).thenReturn(singletonList(accommodation));
+
+        String requestUri = UriComponentsBuilder.fromUriString("/config/SBAC/accommodations?assessmentId=id")
+            .build()
+            .toUriString();
+
+        http.perform(get(requestUri)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("[0].defaultAccommodation", is(true)))
+            .andExpect(jsonPath("[0].code", is("code")))
+            .andExpect(jsonPath("[0].value", is("value")))
+            .andExpect(jsonPath("[0].allowChange", is(true)))
+            .andExpect(jsonPath("[0].dependsOnToolType", is("depends")))
+            .andExpect(jsonPath("[0].allowCombine", is(false)))
+            .andExpect(jsonPath("[0].disableOnGuestSession", is(true)))
+            .andExpect(jsonPath("[0].entryControl", is(false)))
+            .andExpect(jsonPath("[0].functional", is(true)))
+            .andExpect(jsonPath("[0].segmentPosition", is(99)))
+            .andExpect(jsonPath("[0].toolMode", is("toolMode")))
+            .andExpect(jsonPath("[0].toolTypeSortOrder", is(25)))
+            .andExpect(jsonPath("[0].toolValueSortOrder", is(50)))
+            .andExpect(jsonPath("[0].visible", is(true)))
+            .andExpect(jsonPath("[0].type", is("type")));
+    }
+
+    @Test
+    public void shouldRequireAccommodationId() throws Exception {
+        String requestUri = UriComponentsBuilder.fromUriString("/config/SBAC/accommodations")
+            .build()
+            .toUriString();
+
+        http.perform(get(requestUri)
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isBadRequest());
     }
 }

--- a/service/src/test/java/tds/config/web/endpoints/AccommodationControllerTest.java
+++ b/service/src/test/java/tds/config/web/endpoints/AccommodationControllerTest.java
@@ -35,11 +35,22 @@ public class AccommodationControllerTest {
     }
 
     @Test
-    public void shouldReturnAccommodations() {
+    public void shouldReturnAccommodationsByAssessmentKey() {
         Accommodation accommodation = new Accommodation.Builder().build();
-        when(accommodationsService.findAccommodations("key")).thenReturn(Collections.singletonList(accommodation));
+        when(accommodationsService.findAccommodationsByAssessmentKey("key")).thenReturn(Collections.singletonList(accommodation));
 
         ResponseEntity<List<Accommodation>> response = controller.findAccommodations("key");
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).containsOnly(accommodation);
+    }
+
+    @Test
+    public void shouldReturnAccommodationsByAssessmentId() {
+        Accommodation accommodation = new Accommodation.Builder().build();
+        when(accommodationsService.findAccommodationsByAssessmentId("client", "id")).thenReturn(Collections.singletonList(accommodation));
+
+        ResponseEntity<List<Accommodation>> response = controller.findAccommodations("client", "id");
 
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
         assertThat(response.getBody()).containsOnly(accommodation);


### PR DESCRIPTION
The accommodation service and repository belong in assessment service and the object long term, but with all the churn there I want to do that separate from this feature request.

This fetches accommodations by assessment id.  Based on the assessment id we do not know if it is segmented without doing another lookup so instead I just have all the unions in a single call.  We also need to get the count for all accommodations which is the `ValCount` in the legacy code.