### PR TITLE
Externalize config-service properties

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,6 +26,7 @@
         <integration-tests.skip>true</integration-tests.skip>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <docker.image.prefix>fwsbac</docker.image.prefix>
+        <spring.cloud.config.version>1.2.2.RELEASE</spring.cloud.config.version>
 
         <tds.config.client.version>0.0.1-SNAPSHOT</tds.config.client.version>
         <tds.common.version>0.0.1-SNAPSHOT</tds.common.version>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -22,6 +22,18 @@
         <assertj.version>3.4.1</assertj.version>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-config</artifactId>
+                <version>${spring.cloud.config.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.opentestsystem.config</groupId>
@@ -54,6 +66,11 @@
         </dependency>
 
         <!-- Spring dependencies -->
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-config</artifactId>
+        </dependency>
+
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-hateoas</artifactId>

--- a/service/src/main/docker/Dockerfile
+++ b/service/src/main/docker/Dockerfile
@@ -12,5 +12,6 @@ COPY docker-startup.sh docker-startup.sh
 COPY tds-config-service-0.0.1-SNAPSHOT.jar tds-config-service.jar
 
 RUN sh -c 'touch /tds-config-service.jar /docker-startup.sh'
+RUN apk --no-cache add curl
 
 ENTRYPOINT ["/docker-startup.sh"]

--- a/service/src/main/docker/docker-startup.sh
+++ b/service/src/main/docker/docker-startup.sh
@@ -6,19 +6,4 @@
 #
 #-----------------------------------------------------------------------------------------------------------------------
 
-java \
-    -Dspring.datasource.url="jdbc:mysql://${CONFIG_DB_HOST}:${CONFIG_DB_PORT}/${CONFIG_DB_NAME}" \
-    -Dspring.datasource.username="${CONFIG_DB_USER}" \
-    -Dspring.datasource.password="${CONFIG_DB_PASSWORD}" \
-    -Dspring.datasource.type=com.zaxxer.hikari.HikariDataSource \
-    -Dspring.datasource.driver-class-name=com.mysql.jdbc.Driver \
-    -Dspring.datasource.testWhileIdle=true \
-    -Dspring.datasource.timeBetweenEvictionRunsMillis=60000 \
-    -Dspring.datasource.validationQuery="SELECT 1" \
-    -jar /tds-config-service.jar \
-    --server-port="8080" \
-    --server.undertow.buffer-size=16384 \
-    --server.undertow.buffers-per-region=20 \
-    --server.undertow.io-threads=64 \
-    --server.undertow.worker-threads=512 \
-    --server.undertow.direct-buffers=true \
+java -jar /tds-config-service.jar

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  profiles: local-development
+  datasource:
+    url: ${sbac.jdbc.host}/configs
+    username: ${sbac.jdbc.user}
+    password: ${sbac.jdbc.password}
+    type: com.zaxxer.hikari.HikariDataSource
+    driver-class-name: com.mysql.jdbc.Driver
+  mvc:
+    throw-exception-if-no-handler-found: false
+  resources:
+    add-mappings: false
+
+flyway:
+  enabled: false
+
+server:
+  port: 8083
+  undertow:
+    buffer-size: 16384
+    buffers-per-region: 20
+    io-threads: 64
+    worker-threads: 512
+    direct-buffers: true

--- a/service/src/main/resources/bootstrap.yml
+++ b/service/src/main/resources/bootstrap.yml
@@ -1,0 +1,8 @@
+spring:
+  application:
+    name: tds-config-service
+  cloud:
+    config:
+      uri: ${CONFIG_SERVICE_URL:http://localhost:8888}
+      enabled: ${CONFIG_SERVICE_ENABLED:false}
+      fail-fast: ${CONFIG_SERVICE_ENABLED:false}

--- a/service/src/test/resources/application.yml
+++ b/service/src/test/resources/application.yml
@@ -1,0 +1,24 @@
+spring:
+  datasource:
+    url: ${sbac.jdbc.host}/configs
+    username: ${sbac.jdbc.user}
+    password: ${sbac.jdbc.password}
+    type: com.zaxxer.hikari.HikariDataSource
+    driver-class-name: com.mysql.jdbc.Driver
+  mvc:
+    throw-exception-if-no-handler-found: false
+  resources:
+    add-mappings: false
+
+flyway:
+  enabled: true
+  baseline-on-migrate: true
+  out-of-order: true
+
+server:
+  undertow:
+    buffer-size: 16384
+    buffers-per-region: 20
+    io-threads: 64
+    worker-threads: 512
+    direct-buffers: true


### PR DESCRIPTION
Externalize configuration properties:
1. Remove properties from docker-container startup script
2. Add bootstrap.yml properties for connecting to a spring cloud config service
3. Add required maven dependencies
4. Add runtime application.yml with default properties and a local-development profile
5. Add test application.yml with default testing properties to allow running unit/integration tests with a local database
