### PR TITLE
Secure actuator endpoints

### DIFF
--- a/service/src/main/java/tds/config/configuration/ConfigServiceApplicationConfiguration.java
+++ b/service/src/main/java/tds/config/configuration/ConfigServiceApplicationConfiguration.java
@@ -7,6 +7,7 @@ import tds.common.configuration.CacheConfiguration;
 import tds.common.configuration.DataSourceConfiguration;
 import tds.common.configuration.JacksonObjectMapperConfiguration;
 import tds.common.configuration.RestTemplateConfiguration;
+import tds.common.configuration.SecurityConfiguration;
 import tds.common.web.advice.ExceptionAdvice;
 
 /**
@@ -18,7 +19,8 @@ import tds.common.web.advice.ExceptionAdvice;
     RestTemplateConfiguration.class,
     DataSourceConfiguration.class,
     JacksonObjectMapperConfiguration.class,
-    CacheConfiguration.class
+    CacheConfiguration.class,
+    SecurityConfiguration.class
 })
 public class ConfigServiceApplicationConfiguration {
 }

--- a/service/src/main/resources/application.yml
+++ b/service/src/main/resources/application.yml
@@ -1,3 +1,9 @@
+#Configure the Spring Actuator endpoints to require an authenticated user with the MANAGEMENT role
+management:
+  security:
+    roles: MANAGEMENT
+
+---
 spring:
   profiles: local-development
   datasource:
@@ -10,6 +16,13 @@ spring:
     throw-exception-if-no-handler-found: false
   resources:
     add-mappings: false
+
+#Configure the default Spring Security user with the MANAGEMENT role
+security:
+  user:
+    name: user
+    password: password
+    role: MANAGEMENT
 
 flyway:
   enabled: false


### PR DESCRIPTION
This is just an update to use the new SecurityConfiguration from the TDS_Common library.  (If we don't, all the endpoints will be locked down by default since we have Spring Security on the classpath.)

I also added a default user/pass to the local-development profile and added a default MANAGEMENT required role when accessing the actuator endpoints.

NOTE: These changes will need to be done to all the services, and the merging of the associated TDS_Common and microservice changes will need to be coordinated to avoid either locking down endpoints or failing to start because setting the management.security.roles property causes a NoClassDef exception that crashes the microservice if Spring Security isn't on the classpath...  Which is a little annoying.