### PR TITLE
Merge Release 0.0.2 of parent POM, Client Lib, and Service into master

### DIFF
--- a/client/pom.xml
+++ b/client/pom.xml
@@ -15,7 +15,7 @@
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
-        <developerConnection>scm:git:https://git@github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
+        <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
         <tag>HEAD</tag>
     </scm>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>tds-config-client</name>
     <description>The client classes for interacting with the config service</description>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
 
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
-        <tag>HEAD</tag>
+        <tag>tds-config-client-0.0.2</tag>
     </scm>
 
     <properties>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-config</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.2</version>
     </parent>
 
     <scm>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>tds-config-client</name>
     <description>The client classes for interacting with the config service</description>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
-        <tag>tds-config-client-0.0.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1,18 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>tds-config-client</artifactId>
     <packaging>jar</packaging>
-
     <name>tds-config-client</name>
     <description>The client classes for interacting with the config service</description>
+    <version>0.0.2-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-config</artifactId>
         <version>0.0.2-SNAPSHOT</version>
     </parent>
+
+    <scm>
+        <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
+        <developerConnection>scm:git:https://git@github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
+        <url>https://github.com/SmarterApp/TDS_ConfigService</url>
+        <tag>HEAD</tag>
+    </scm>
 
     <properties>
         <maven.compiler.source>1.7</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -72,10 +72,9 @@
             <plugin>
                 <artifactId>maven-release-plugin</artifactId>
                 <configuration>
-                    <tagNameFormat>@{project.version}</tagNameFormat>
                     <useReleaseProfile>false</useReleaseProfile>
                     <releaseProfiles>release</releaseProfiles>
-                    <autoVersionSubmodules>true</autoVersionSubmodules>
+                    <autoVersionSubmodules>false</autoVersionSubmodules>
                 </configuration>
             </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <artifactId>tds-config</artifactId>
     <name>tds-config</name>
     <packaging>pom</packaging>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
-        <tag>tds-config-0.0.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -35,9 +35,6 @@
         <mockito.version>1.10.19</mockito.version>
         <joda-time.version>2.9.5</joda-time.version>
 
-        <tds.common.version>0.0.1</tds.common.version>
-        <tds-common-legacy.version>0.0.1</tds-common-legacy.version>
-
         <maven.compiler.plugin.version>3.5.1</maven.compiler.plugin.version>
         <maven.jar.plugin.version>2.3.2</maven.jar.plugin.version>
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
@@ -86,9 +83,9 @@
 
     <distributionManagement>
         <repository>
-            <id>bintray-smarter-app-open-test-system</id>
-            <name>smarter-app-open-test-system</name>
-            <url>https://api.bintray.com/maven/smarter-app/open-test-system/${publish.package.name}/;publish=1</url>
+            <id>central</id>
+            <name>airdev-releases</name>
+            <url>https://airdev.jfrog.io/airdev/libs-releases-local</url>
         </repository>
     </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,6 @@
         <maven.release.plugin.version>2.5.3</maven.release.plugin.version>
         <maven.source.plugin.version>2.1.2</maven.source.plugin.version>
         <maven.toolchains.plugin.version>1.1</maven.toolchains.plugin.version>
-        <publish.package.name>org.opentestsystem.tds.config</publish.package.name>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
     <artifactId>tds-config</artifactId>
     <name>tds-config</name>
     <packaging>pom</packaging>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
-        <tag>HEAD</tag>
+        <tag>tds-config-0.0.2</tag>
     </scm>
 
     <modules>

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
-        <developerConnection>scm:git:https://git@github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
+        <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
         <tag>HEAD</tag>
     </scm>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -15,7 +15,7 @@
 
     <scm>
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
-        <developerConnection>scm:git:https://git@github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
+        <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
         <tag>HEAD</tag>
     </scm>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>tds-config-service</name>
     <description>The microservice for configuration</description>
-    <version>0.0.2</version>
+    <version>0.0.3-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
-        <tag>tds-config-service-0.0.2</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <properties>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -10,7 +10,7 @@
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
         <artifactId>tds-config</artifactId>
-        <version>0.0.2-SNAPSHOT</version>
+        <version>0.0.2</version>
     </parent>
 
     <scm>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -5,7 +5,7 @@
     <packaging>jar</packaging>
     <name>tds-config-service</name>
     <description>The microservice for configuration</description>
-    <version>0.0.2-SNAPSHOT</version>
+    <version>0.0.2</version>
 
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
@@ -17,7 +17,7 @@
         <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
         <developerConnection>scm:git:git://github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
         <url>https://github.com/SmarterApp/TDS_ConfigService</url>
-        <tag>HEAD</tag>
+        <tag>tds-config-service-0.0.2</tag>
     </scm>
 
     <properties>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -26,6 +26,7 @@
 
         <tds.common.version>0.0.2</tds.common.version>
         <tds.common.legacy.version>0.0.2</tds.common.legacy.version>
+        <tds.config.client.version>0.0.2</tds.config.client.version>
     </properties>
 
     <dependencyManagement>
@@ -44,7 +45,7 @@
         <dependency>
             <groupId>org.opentestsystem.delivery</groupId>
             <artifactId>tds-config-client</artifactId>
-            <version>${project.version}</version>
+            <version>${tds.config.client.version}</version>
         </dependency>
 
         <dependency>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-
     <artifactId>tds-config-service</artifactId>
     <packaging>jar</packaging>
-
     <name>tds-config-service</name>
     <description>The microservice for configuration</description>
+    <version>0.0.2-SNAPSHOT</version>
 
     <parent>
         <groupId>org.opentestsystem.delivery</groupId>
@@ -14,9 +13,19 @@
         <version>0.0.2-SNAPSHOT</version>
     </parent>
 
+    <scm>
+        <connection>scm:git:https://github.com/SmarterApp/TDS_ConfigService.git</connection>
+        <developerConnection>scm:git:https://git@github.com/SmarterApp/TDS_ConfigService.git</developerConnection>
+        <url>https://github.com/SmarterApp/TDS_ConfigService</url>
+        <tag>HEAD</tag>
+    </scm>
+
     <properties>
         <java.version>1.8</java.version>
         <assertj.version>3.4.1</assertj.version>
+
+        <tds.common.version>0.0.2</tds.common.version>
+        <tds.common.legacy.version>0.0.2</tds.common.legacy.version>
     </properties>
 
     <dependencyManagement>
@@ -47,7 +56,7 @@
         <dependency>
             <groupId>org.opentestsystem.delivery</groupId>
             <artifactId>tds-common-legacy</artifactId>
-            <version>${tds-common-legacy.version}</version>
+            <version>${tds.common.legacy.version}</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This PR updates our TDS_ConfigService for separate releases of the parent pom, client library, and service.  They can all be independently versioned, and there are no snapshot dependencies between them.  This is what we will be doing for all of our services.