### PR TITLE
Added an endpoint to fetch all assessment ids that are force complete

### DIFF
--- a/service/src/main/java/tds/config/repositories/ConfigRepository.java
+++ b/service/src/main/java/tds/config/repositories/ConfigRepository.java
@@ -13,6 +13,7 @@
 
 package tds.config.repositories;
 
+import java.util.Collection;
 import java.util.List;
 
 import tds.config.ClientSystemFlag;
@@ -37,4 +38,12 @@ public interface ConfigRepository {
      * @return A collection of {@link tds.config.ClientSystemFlag} records for the specified client name.
      */
     List<ClientSystemFlag> findClientSystemFlags(final String clientName);
+
+    /**
+     * Fetch all assessment ids that are configured for force complete
+     *
+     * @param clientName client name
+     * @return collection of assessment ids that have force complete enabled
+     */
+    Collection<String> findForceCompleteAssessmentIds(final String clientName);
 }

--- a/service/src/main/java/tds/config/repositories/impl/ConfigRepositoryImpl.java
+++ b/service/src/main/java/tds/config/repositories/impl/ConfigRepositoryImpl.java
@@ -23,6 +23,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.jdbc.core.namedparam.SqlParameterSource;
 import org.springframework.stereotype.Repository;
 
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 
@@ -72,5 +73,21 @@ public class ConfigRepositoryImpl implements ConfigRepository {
         }
 
         return clientSystemFlags;
+    }
+
+    @Override
+    public Collection<String> findForceCompleteAssessmentIds(final String clientName) {
+        final SqlParameterSource parameters = new MapSqlParameterSource("clientName", clientName);
+
+        final String SQL =
+            "SELECT \n" +
+                "  testid \n" +
+                "FROM \n " +
+                "  configs.client_testproperties " +
+                "WHERE " +
+                "  clientname = :clientName \n" +
+                "  AND forcecomplete = true";
+
+        return jdbcTemplate.queryForList(SQL, parameters, String.class);
     }
 }

--- a/service/src/main/java/tds/config/services/ConfigService.java
+++ b/service/src/main/java/tds/config/services/ConfigService.java
@@ -13,6 +13,7 @@
 
 package tds.config.services;
 
+import java.util.Collection;
 import java.util.Optional;
 
 import tds.config.ClientSystemFlag;
@@ -29,4 +30,12 @@ public interface ConfigService {
      * @return The {@link Optional<ClientSystemFlag>} that matches the client and audit name.
      */
     Optional<ClientSystemFlag> findClientSystemFlag(final String clientName, final String type);
+
+    /**
+     * Retrieves assessment ids that are force complete enabled
+     *
+     * @param clientName client name associated with assessment ids
+     * @return list of assessment ids
+     */
+    Collection<String> findForceCompleteAssessmentIds(final String clientName);
 }

--- a/service/src/main/java/tds/config/services/impl/ConfigServiceImpl.java
+++ b/service/src/main/java/tds/config/services/impl/ConfigServiceImpl.java
@@ -17,6 +17,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 
@@ -48,5 +49,10 @@ public class ConfigServiceImpl implements ConfigService {
         return clientSystemFlags.stream()
             .filter(f -> f.getAuditObject().equals(type))
             .findFirst();
+    }
+
+    @Override
+    public Collection<String> findForceCompleteAssessmentIds(final String clientName) {
+        return configRepository.findForceCompleteAssessmentIds(clientName);
     }
 }

--- a/service/src/main/java/tds/config/web/endpoints/ConfigController.java
+++ b/service/src/main/java/tds/config/web/endpoints/ConfigController.java
@@ -22,6 +22,8 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.Collection;
+
 import tds.common.web.exceptions.NotFoundException;
 import tds.config.ClientSystemFlag;
 import tds.config.services.ConfigService;
@@ -43,5 +45,11 @@ class ConfigController {
             .orElseThrow(() -> new NotFoundException("Could not find ClientSystemFlag for client name %s and type %s", clientName, type));
 
         return ResponseEntity.ok(clientSystemFlag);
+    }
+
+    @GetMapping(value = "/client-test-properties/{clientName}/forceComplete", produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    ResponseEntity<Collection<String>> findForceCompleteAssessmentIds(@PathVariable final String clientName) {
+        return ResponseEntity.ok(configService.findForceCompleteAssessmentIds(clientName));
     }
 }

--- a/service/src/test/java/tds/config/repositories/impl/ConfigRepositoryImplIntegrationTests.java
+++ b/service/src/test/java/tds/config/repositories/impl/ConfigRepositoryImplIntegrationTests.java
@@ -25,6 +25,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Collection;
 import java.util.List;
 
 import tds.config.ClientSystemFlag;
@@ -48,7 +49,10 @@ public class ConfigRepositoryImplIntegrationTests {
         String clientFlagInsertSQL = "INSERT INTO client_systemflags (auditobject,ison,description,clientname,ispracticetest,datechanged,datepublished) " +
             "VALUES ('accommodations',1,'keeps an audit trail of various changes to accommodations settings','SBAC_PT',1,'2011-06-01 11:27:47.980',NULL);";
 
+        String clientTestPropertiesInsertSQL = "INSERT INTO `client_testproperties` VALUES ('SBAC','(SBAC) STSAssessment-ICA-5-2017-2018-81638630',3,NULL,2,NULL,'\\0','\u0001','Grade 5 ELA','','\u0001','\\0','ELA',NULL,NULL,'\u0001','\u0001',NULL,NULL,NULL,NULL,'ELA',NULL,'tds-testform','tds-testwindow','\\0','\\0',NULL,NULL,'\u0001','tds-testmode','\\0','\\0','\\0','\\0',1,0,'\\0','Grade 5',NULL,0,NULL,'\\0')";
+
         jdbcTemplate.update(clientFlagInsertSQL, new MapSqlParameterSource());
+        jdbcTemplate.update(clientTestPropertiesInsertSQL, new MapSqlParameterSource());
     }
 
     @After
@@ -79,5 +83,11 @@ public class ConfigRepositoryImplIntegrationTests {
         List<ClientSystemFlag> result = configRepository.findClientSystemFlags(clientName);
 
         assertThat(result.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void shouldGetForceCompleteAssessmentIds() {
+        Collection<String> assessmentIds = configRepository.findForceCompleteAssessmentIds("SBAC");
+        assertThat(assessmentIds).containsOnly("(SBAC) STSAssessment-ICA-5-2017-2018-81638630");
     }
 }

--- a/service/src/test/java/tds/config/services/impl/ConfigServiceImplTest.java
+++ b/service/src/test/java/tds/config/services/impl/ConfigServiceImplTest.java
@@ -21,12 +21,11 @@ import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-import tds.config.ClientLanguage;
 import tds.config.ClientSystemFlag;
-import tds.config.ClientSystemMessage;
 import tds.config.repositories.ConfigRepository;
 import tds.config.services.ConfigService;
 
@@ -73,6 +72,13 @@ public class ConfigServiceImplTest {
         Optional<ClientSystemFlag> result = configService.findClientSystemFlag("SBAC_PT", "foo");
 
         assertThat(result).isNotPresent();
+    }
+
+    @Test
+    public void shouldReturnForceCompleteAssessmentIds() {
+        when(mockConfigRepository.findForceCompleteAssessmentIds("SBAC")).thenReturn(Collections.singletonList("testId"));
+
+        assertThat(configService.findForceCompleteAssessmentIds("SBAC")).containsExactly("testId");
     }
 
     private List<ClientSystemFlag> getMockClientSystemFlag() {

--- a/service/src/test/java/tds/config/web/endpoints/ConfigControllerIntegrationTests.java
+++ b/service/src/test/java/tds/config/web/endpoints/ConfigControllerIntegrationTests.java
@@ -23,6 +23,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 
+import java.util.Collections;
 import java.util.Optional;
 
 import tds.common.configuration.SecurityConfiguration;
@@ -79,5 +80,16 @@ public class ConfigControllerIntegrationTests {
         http.perform(get("/config/client-system-flags/" + clientName + "/" + auditObject)
             .contentType(MediaType.APPLICATION_JSON))
             .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void shouldGetForceCompleteAssessmentIds() throws Exception {
+        final String clientName = "SBAC";
+
+        when(mockConfigService.findForceCompleteAssessmentIds(clientName)).thenReturn(Collections.singletonList("testId"));
+
+        http.perform(get("/config/client-test-properties/" + clientName + "/forceComplete")
+            .contentType(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk());
     }
 }

--- a/service/src/test/java/tds/config/web/endpoints/ConfigControllerTest.java
+++ b/service/src/test/java/tds/config/web/endpoints/ConfigControllerTest.java
@@ -22,6 +22,8 @@ import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Optional;
 
 import tds.common.web.exceptions.NotFoundException;
@@ -78,5 +80,15 @@ public class ConfigControllerTest {
             .thenReturn(Optional.empty());
 
         configController.getClientSystemFlag(clientName, auditObject);
+    }
+
+    @Test
+    public void shouldFindAssessmentsThatAreForceComplete() {
+        when(mockConfigService.findForceCompleteAssessmentIds("SBAC")).thenReturn(Collections.singletonList("testId"));
+
+        ResponseEntity<Collection<String>> responseEntity = configController.findForceCompleteAssessmentIds("SBAC");
+
+        assertThat(responseEntity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(responseEntity.getBody()).containsExactly("testId");
     }
 }


### PR DESCRIPTION
For force submit I need an endpoint to fetch all assessment ids that are force completed.  This is also on assessment but that query joins a ton of tables and brings back data that isn't needed for this flow.